### PR TITLE
[FIX] vistas y traducción product_season

### DIFF
--- a/product_season/__openerp__.py
+++ b/product_season/__openerp__.py
@@ -33,6 +33,7 @@
         'views/season.xml',
         'views/brand.xml',
         'views/product.xml',
+        'security/ir.model.access.csv',
     ],
     'installable': True,
 }

--- a/product_season/__openerp__.py
+++ b/product_season/__openerp__.py
@@ -34,6 +34,5 @@
         'views/brand.xml',
         'views/product.xml',
     ],
-    'data': [],
     'installable': True,
 }

--- a/product_season/i18n/es.po
+++ b/product_season/i18n/es.po
@@ -1,0 +1,128 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_season
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-20 07:52+0000\n"
+"PO-Revision-Date: 2015-08-20 07:52+0000\n"
+"Last-Translator: Ismael Calvo <ismael.calvo@factorlibre.com>\n"
+"Language-Team: FactorLibre <info@factorlibre.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_season
+#: view:product.template:product_season.product_template_search_view
+#: field:product.template,brand_id:0
+msgid "Brand"
+msgstr "Marca"
+
+#. module: product_season
+#: view:product.brand:product_season.product_brand_search_view
+msgid "Brand Name"
+msgstr "Nombre de la marca"
+
+#. module: product_season
+#: model:ir.actions.act_window,name:product_season.product_brand_action
+#: model:ir.ui.menu,name:product_season.menu_product_brand_action
+msgid "Brands"
+msgstr "Marcas"
+
+#. module: product_season
+#: field:product.brand,create_uid:0
+#: field:product.season,create_uid:0
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: product_season
+#: field:product.brand,create_date:0
+#: field:product.season,create_date:0
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: product_season
+#: view:product.brand:product_season.product_brand_search_view
+#: view:product.season:product_season.product_season_search_view
+msgid "Group by..."
+msgstr "Agrupar por..."
+
+#. module: product_season
+#: field:product.brand,id:0
+#: field:product.season,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: product_season
+#: field:product.brand,write_uid:0
+#: field:product.season,write_uid:0
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: product_season
+#: field:product.brand,write_date:0
+#: field:product.season,write_date:0
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: product_season
+#: view:product.brand:product_season.product_brand_search_view
+#: field:product.brand,manufacturer_id:0
+#: view:product.template:product_season.product_template_search_view
+#: field:product.template,manufacturer_id:0
+msgid "Manufacturer"
+msgstr "Fabricante"
+
+#. module: product_season
+#: field:product.brand,name:0
+#: field:product.season,name:0
+msgid "Name"
+msgstr "Nombre"
+
+#. module: product_season
+#: view:product.season:product_season.product_season_form_view
+#: view:product.season:product_season.product_season_search_view
+#: view:product.season:product_season.product_season_tree_view
+msgid "Product Season"
+msgstr "Temporada del producto"
+
+#. module: product_season
+#: model:ir.model,name:product_season.model_product_template
+msgid "Product Template"
+msgstr "Plantilla de producto"
+
+#. module: product_season
+#: model:ir.model,name:product_season.model_product_brand
+#: view:product.brand:product_season.product_brand_form_view
+#: view:product.brand:product_season.product_brand_search_view
+#: view:product.brand:product_season.product_brand_tree_view
+msgid "Product brand"
+msgstr "Marca del producto"
+
+#. module: product_season
+#: model:ir.model,name:product_season.model_product_season
+msgid "Product season"
+msgstr "Temporada del producto"
+
+#. module: product_season
+#: view:product.season:product_season.product_season_search_view
+#: view:product.template:product_season.product_template_search_view
+#: field:product.template,season_id:0
+msgid "Season"
+msgstr "Temporada"
+
+#. module: product_season
+#: model:ir.actions.act_window,name:product_season.product_season_action
+#: model:ir.ui.menu,name:product_season.menu_product_season_action
+msgid "Seasons"
+msgstr "Temporadas"
+
+#. module: product_season
+#: view:product.season:product_season.product_season_search_view
+#: field:product.season,year:0
+msgid "Year"
+msgstr "Año"
+

--- a/product_season/i18n/product_season.pot
+++ b/product_season/i18n/product_season.pot
@@ -1,0 +1,128 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * product_season
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-20 07:52+0000\n"
+"PO-Revision-Date: 2015-08-20 07:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: product_season
+#: view:product.template:product_season.product_template_search_view
+#: field:product.template,brand_id:0
+msgid "Brand"
+msgstr ""
+
+#. module: product_season
+#: view:product.brand:product_season.product_brand_search_view
+msgid "Brand Name"
+msgstr ""
+
+#. module: product_season
+#: model:ir.actions.act_window,name:product_season.product_brand_action
+#: model:ir.ui.menu,name:product_season.menu_product_brand_action
+msgid "Brands"
+msgstr ""
+
+#. module: product_season
+#: field:product.brand,create_uid:0
+#: field:product.season,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: product_season
+#: field:product.brand,create_date:0
+#: field:product.season,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: product_season
+#: view:product.brand:product_season.product_brand_search_view
+#: view:product.season:product_season.product_season_search_view
+msgid "Group by..."
+msgstr ""
+
+#. module: product_season
+#: field:product.brand,id:0
+#: field:product.season,id:0
+msgid "ID"
+msgstr ""
+
+#. module: product_season
+#: field:product.brand,write_uid:0
+#: field:product.season,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: product_season
+#: field:product.brand,write_date:0
+#: field:product.season,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: product_season
+#: view:product.brand:product_season.product_brand_search_view
+#: field:product.brand,manufacturer_id:0
+#: view:product.template:product_season.product_template_search_view
+#: field:product.template,manufacturer_id:0
+msgid "Manufacturer"
+msgstr ""
+
+#. module: product_season
+#: field:product.brand,name:0
+#: field:product.season,name:0
+msgid "Name"
+msgstr ""
+
+#. module: product_season
+#: view:product.season:product_season.product_season_form_view
+#: view:product.season:product_season.product_season_search_view
+#: view:product.season:product_season.product_season_tree_view
+msgid "Product Season"
+msgstr ""
+
+#. module: product_season
+#: model:ir.model,name:product_season.model_product_template
+msgid "Product Template"
+msgstr ""
+
+#. module: product_season
+#: model:ir.model,name:product_season.model_product_brand
+#: view:product.brand:product_season.product_brand_form_view
+#: view:product.brand:product_season.product_brand_search_view
+#: view:product.brand:product_season.product_brand_tree_view
+msgid "Product brand"
+msgstr ""
+
+#. module: product_season
+#: model:ir.model,name:product_season.model_product_season
+msgid "Product season"
+msgstr ""
+
+#. module: product_season
+#: view:product.season:product_season.product_season_search_view
+#: view:product.template:product_season.product_template_search_view
+#: field:product.template,season_id:0
+msgid "Season"
+msgstr ""
+
+#. module: product_season
+#: model:ir.actions.act_window,name:product_season.product_season_action
+#: model:ir.ui.menu,name:product_season.menu_product_season_action
+msgid "Seasons"
+msgstr ""
+
+#. module: product_season
+#: view:product.season:product_season.product_season_search_view
+#: field:product.season,year:0
+msgid "Year"
+msgstr ""
+

--- a/product_season/security/ir.model.access.csv
+++ b/product_season/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_season,product.season line,model_product_season,base.group_user,1,0,0,0
+access_product_season_sale_manager,product.season manager line,model_product_season,base.group_sale_manager,1,1,1,1
+access_product_brand,product.brand line,model_product_brand,base.group_user,1,0,0,0
+access_product_brand_sale_manager,product.brand manager line,model_product_brand,base.group_sale_manager,1,1,1,1

--- a/product_season/views/product.xml
+++ b/product_season/views/product.xml
@@ -40,7 +40,7 @@
         <record id="product_template_form_view" model="ir.ui.view">
             <field name="name">product.template.product.form</field>
             <field name="model">product.template</field>
-            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//field[@name='default_code']" position="after">


### PR DESCRIPTION
- El `data` del `__openerp__.py` está duplicado y el segundo vacío, por lo que no se cargan las vistas.
- El campo `default_code` no existe en la vista padre `product.product_template_form_view` y da error al actualizar el módulo, la he cambiado por `product.product_template_only_form_view`.
- Añado la traducción al español.
